### PR TITLE
ref: update uri management & include sliced domain in offchain_resolver error msg

### DIFF
--- a/src/interface/resolver.cairo
+++ b/src/interface/resolver.cairo
@@ -5,5 +5,8 @@ trait IResolver<TContractState> {
     fn resolve(
         self: @TContractState, domain: Span<felt252>, field: felt252, hint: Span<felt252>
     ) -> felt252;
-    fn update_uri(ref self: TContractState, new_uri: Span<felt252>);
+
+    fn get_uris(self: @TContractState) -> Array<felt252>;
+    fn add_uri(ref self: TContractState, new_uri: Span<felt252>);
+    fn remove_uri(ref self: TContractState, index: felt252);
 }


### PR DESCRIPTION
This PR : 
- updates how we handle uri & the event we fire on modification, you can now store multiple uris
- updates the `offchain_resolver` error message to also include the sliced domain, followed by the list of uri. 